### PR TITLE
Lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ include = ["/src", "/Cargo.toml", "/README.md"]
 [dependencies]
 serde-metafile = "0.1"
 serde_json = "1"
+cargo-lock = "10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ include = ["/src", "/Cargo.toml", "/README.md"]
 serde-metafile = "0.1"
 serde_json = "1"
 cargo-lock = "10"
+clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 bloaty ./bloaty -d sections,symbols -n 0  --csv | bloaty-metafile > meta.json
 
-bloaty ./target/release/bloaty-metafile -d sections,symbols -n 0  --csv | bloaty-metafile --name=bloaty-metafile --cargo-lock=Cargo.lock  > meta.json
-
+bloaty ./target/release/bloaty-metafile -d sections,symbols -n 0  --csv | bloaty-metafile --name=bloaty-metafile --lock=Cargo.lock  > meta.json
 ```
 
 ## Esbuild Bundle Size Analyzer

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 bloaty ./bloaty -d sections,symbols -n 0  --csv | bloaty-metafile > meta.json
 
+bloaty ./target/release/bloaty-metafile -d sections,symbols -n 0  --csv | bloaty-metafile --name=bloaty-metafile --cargo-lock=Cargo.lock  > meta.json
+
 ```
 
 ## Esbuild Bundle Size Analyzer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl Node {
     }
 }
 
-pub fn get_tree(csv: &str, cargo_lock: Option<String>) -> Node {
+pub fn get_tree(csv: &str, lock: Option<String>) -> Node {
     let mut tree = Node {
         name: "__ROOT__".to_string(),
         vmsize: 0,
@@ -49,7 +49,7 @@ pub fn get_tree(csv: &str, cargo_lock: Option<String>) -> Node {
         nodes: HashMap::new(),
     };
 
-    let lock = cargo_lock.and_then(|p| Lockfile::load(&p).ok());
+    let lock = lock.and_then(|p| Lockfile::load(&p).ok());
     let mut parent: HashMap<String, String> = HashMap::new();
     if let Some(lock) = lock {
         for pkg in lock.packages {
@@ -105,8 +105,8 @@ pub fn get_tree(csv: &str, cargo_lock: Option<String>) -> Node {
     tree
 }
 
-pub fn from_csv(csv: &str, name: &str, cargo_lock: Option<String>) -> Metafile {
-    let tree = get_tree(csv, cargo_lock);
+pub fn from_csv(csv: &str, name: &str, lock: Option<String>) -> Metafile {
+    let tree = get_tree(csv, lock);
 
     convert_node_to_metafile(tree, name)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,6 @@ impl Node {
                     name: part.to_string(),
                     vmsize,
                     filesize,
-                    vmsize,
-                    filesize,
                     count: 1,
                     nodes: HashMap::new(),
                 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,20 @@
 use bloaty_metafile::from_csv;
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    #[arg(short, long, default_value = "Binary-Size-Analyzer")]
+    pub name: String,
+
+    #[arg(short, long)]
+    pub cargo_lock: Option<String>,
+}
+
 fn main() {
+    let Args { name, cargo_lock } = Args::parse();
     let csv = std::io::read_to_string(std::io::stdin()).expect("failed to read csv from stdio");
-    let meta = from_csv(&csv);
+    let meta = from_csv(&csv, &name, cargo_lock);
     let s = serde_json::to_string(&meta).expect("failed to serde metafile to json");
     println!("{s}",);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,17 +4,17 @@ use clap::Parser;
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    #[arg(short, long, default_value = "Binary-Size-Analyzer")]
+    #[arg(short, long, default_value = "Binary")]
     pub name: String,
 
     #[arg(short, long)]
-    pub cargo_lock: Option<String>,
+    pub lock: Option<String>,
 }
 
 fn main() {
-    let Args { name, cargo_lock } = Args::parse();
+    let Args { name, lock } = Args::parse();
     let csv = std::io::read_to_string(std::io::stdin()).expect("failed to read csv from stdio");
-    let meta = from_csv(&csv, &name, cargo_lock);
+    let meta = from_csv(&csv, &name, lock);
     let s = serde_json::to_string(&meta).expect("failed to serde metafile to json");
     println!("{s}",);
 }


### PR DESCRIPTION
Because bloaty's output does not contain package information, the sizes of dependencies such as regex are all displayed separately.

![image](https://github.com/user-attachments/assets/802e39bd-8f2e-4929-b37d-bff4fcb641f2)

If a lock file can be provided, the dependency size can be correctly displayed by analyzing the package dependencies.


![image](https://github.com/user-attachments/assets/96a403fb-c004-40c5-9f72-af44e2ea7213)
