### PR TITLE
support short crate path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 permissions:
   contents: write
 
-on: [push]
+on: [push, pull_request]
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 permissions:
   contents: write
 
-on: [push]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           bloaty ./target/bloaty/bloaty-metafile -d sections,symbols -n 0 --csv > bloaty-metafile-${{ matrix.os }}.csv
       - name: bloaty-metafile.json
         run: |
-          bloaty-metafile bloaty-metafile-${{ matrix.os }}.csv --name=bloaty-metafile --deep=0 > bloaty-metafile-${{ matrix.os }}.json
+          bloaty-metafile bloaty-metafile-${{ matrix.os }}.csv --name=bloaty-metafile > bloaty-metafile-${{ matrix.os }}.json
           ls -lh
       - name: Upload
         uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1"
 cargo-lock = "10"
 clap = { version = "4.5", features = ["derive"] }
 csv = "1"
-serde="1"
+serde = "1"
 
 [profile.release]
 debug = false

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If a lock file can be provided, by default, the Cargo.lock file in the current d
 
 For large applications, the dependency tree will be very deep, which will cause the generated JSON to be very large and contain too much useless information. You can use the --deep option to limit the maximum depth of the dependency.
 
-The default value of deep is 8, which is probably suitable for most programs. 0 means no limit
+The default value of deep is 0(no limit)
 
 deep: 4, json: 6.7M
 ![llrt-deep-4](https://github.com/user-attachments/assets/2780c0ff-3a04-4aa3-946f-5c024347f1dd)
@@ -73,7 +73,7 @@ deep: 4, json: 6.7M
 deep: 8, json: 12M
 ![llrt-deep-8](https://github.com/user-attachments/assets/89a786ff-45e6-47b7-a931-edd59d1dff30)
 
-deep: 0(no limit), json: 80M
+deep: 0, json: 80M
 ![llrt-deep-0](https://github.com/user-attachments/assets/b2cbf935-340e-4dbd-8ca3-191340c9ae35)
 
 ## windows

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,13 @@ use clap::Parser;
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    #[arg(short, long, default_value = "Binary")]
+    #[arg(short, long, default_value = "BINARY")]
     pub name: String,
 
     #[arg(short, long)]
     pub lock: Option<String>,
 
-    #[arg(short, long, default_value = "8")]
+    #[arg(short, long, default_value = "0")]
     pub deep: usize,
 
     #[arg()]

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,0 +1,71 @@
+use cargo_lock::Lockfile;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Default)]
+pub struct Packages {
+    dependencies: HashMap<String, HashSet<String>>,
+    parent: HashMap<String, String>,
+}
+
+impl Packages {
+    pub fn from_lock(lock: Lockfile) -> Self {
+        let mut dependencies = HashMap::new();
+        let mut parent = HashMap::new();
+        for pkg in lock.packages {
+            let name = pkg.name.as_str().replace("-", "_");
+            if !parent.contains_key(&name) {
+                parent.insert(name.clone(), name.clone());
+            }
+            for dep in &pkg.dependencies {
+                let dep_name = dep.name.as_str().replace("-", "_");
+                parent.insert(dep_name.clone(), name.clone());
+            }
+
+            let deps: HashSet<String> = HashSet::from_iter(
+                pkg.dependencies
+                    .into_iter()
+                    .map(|i| i.name.as_str().replace("-", "_")),
+            );
+
+            dependencies.insert(name, deps);
+        }
+        Packages {
+            dependencies,
+            parent,
+        }
+    }
+
+    pub fn is_root(&self, id: &str) -> bool {
+        self.parent.get(id).is_some_and(|i| i == id)
+    }
+
+    fn is_direct_dep(&self, id: &str, dep: &str) -> bool {
+        self.dependencies.get(id).is_some_and(|i| i.contains(dep))
+    }
+
+    pub fn get_path(&self, id: &str) -> Vec<String> {
+        if self.is_root(id) {
+            return vec![];
+        }
+        let mut path = vec![];
+        let mut cur = &id.to_string();
+        while let Some(parent) = self.parent.get(cur) {
+            path.push(cur.clone());
+            if parent == cur {
+                break;
+            }
+            cur = parent;
+        }
+
+        let mut post_path = vec![];
+        for i in path.iter().rev() {
+            if self.is_direct_dep(i, id) {
+                let mut short = vec![id.to_string(), i.to_string()];
+                short.extend(post_path.into_iter().rev());
+                return short;
+            }
+            post_path.push(i.clone());
+        }
+        path
+    }
+}


### PR DESCRIPTION
Consider that tokio will be depended on by many crates.

We can use the shortest path to reduce the size of json (80MB -> 60MB)


```
A -> B -> C -> D
A -> E ->D
A -> F ->D
A -> D
```


